### PR TITLE
chore: update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -12,18 +12,25 @@
   "bin": {
     "travis-check-changes": "travis-check-changes.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nfischer/travis-check-changes"
+  },
   "keywords": [
     "travis",
     "CI",
     "changes",
     "after"
   ],
-  "author": "Nate Fischer",
+  "author": "Nate Fischer <ntfschr@gmail.com> (https://github.com/nfischer)",
   "license": "MIT",
   "dependencies": {
-    "shelljs": "^0.7.0"
+    "shelljs": "^0.8.5"
   },
   "devDependencies": {
-    "shelljs-release": "^0.1.4"
+    "shelljs-release": "^0.5.1"
+  },
+  "engines": {
+    "node": ">=8"
   }
 }


### PR DESCRIPTION
No change to logic. This updates dependencies, which includes
shelljs/shelljs#1058.

I'm updating some metadata in the package.json. This also bumps engines
to node v8 because I think ShellJS is the only consumer of this package.